### PR TITLE
增加功能和位置改进

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ## Welcome to my blog!👋: [[Colin‘s Blog]](http://dlcolin.cn)
 
- ![Colin's GitHub stats](https://github-readme-stats.vercel.app/api?username=Colin-614&count_private=true&show_icons=true&include_all_commits=true&hide_border=true&bg_color=30,C9D6FF,E2E2E2&title_color=005AA7&icon_color=005AA7&text_color=005AA7)
+<div align=center><p><a href="https://github.com/Colin-614"><img alt="Colin&#39;s GitHub stats" src="https://github-readme-stats.vercel.app/api?username=Colin-614&amp;count_private=true&amp;show_icons=true&amp;include_all_commits=true&amp;hide_border=true&amp;bg_color=30,C9D6FF,E2E2E2&amp;title_color=005AA7&amp;icon_color=005AA7&amp;text_color=005AA7"/></a></p>
 
 [![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=Colin-614&repo=Colin-614.github.io&hide_border=true&bg_color=30,C9D6FF,E2E2E2&title_color=005AA7&icon_color=005AA7&text_color=005AA7)](https://github.com/Colin-614/Colin-614.github.io)
-
 [![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=Colin-614&repo=Colin-614&hide_border=true&bg_color=30,C9D6FF,E2E2E2&title_color=005AA7&icon_color=005AA7&text_color=005AA7)](https://github.com/Colin-614/Colin-614)


### PR DESCRIPTION
把点击统计的图片跳转到github个人页面（原先是跳转到一个新标签页打开该图片）

个人统计卡片居中